### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.env
+node_modules
+tmp
+.proxyrc*
+!.proxyrc.json.example

--- a/.proxyrc.json.example
+++ b/.proxyrc.json.example
@@ -2,5 +2,6 @@
   "/annotation/": "https://api.europeana.eu/",
   "/entity/": "https://api.europeana.eu/",
   "/record/": "https://api.europeana.eu/",
+  "/content/v1/spaces/CONTENTFUL_SPACE_ID/environments/": "https://graphql.contentful.com",
   "/spaces/CONTENTFUL_SPACE_ID/environments/CONTENTFUL_ENVIRONMENT_ID/": "https://cdn.contentful.com/"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-# Docker image to build and deploy to Cloud Foundry.
-#
-# This does *not* run the proxy/cache app, but is used as the agent in its
-# Jenkins Pipeline.
+FROM node:12-alpine
 
-FROM debian:stable-slim
+ENV NODE_ENV=production
+ENV PORT=8080
+ENV HOST=0.0.0.0
 
 WORKDIR /app
 
-# Install CF CLI
-RUN apt-get -q update && apt-get -yq install gnupg apt-transport-https wget \
-  && wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - \
-  && echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list \
-  && apt-get -q update && apt-get -yq install cf-cli \
-  && rm -rf /var/lib/apt/lists/* \
-  && cf install-plugin blue-green-deploy -f -r CF-Community
+COPY index.js package*.json ./
+
+RUN npm install
+
+ENTRYPOINT ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,29 @@
 [Express](https://expressjs.com/) web application to proxy requests to APIs and
 cache their responses in Redis.
 
+## Docker
+
+### Build
+
+```
+docker build -t europeana/api-proxy-cache .
+```
+
+### Configure
+
+Copy [.proxyrc.json.example](.proxyrc.json.example) to .proxyrc.json and
+adapt for your environment.
+
+### Run
+
+```
+docker run -it \
+  --mount type=bind,source="$(pwd)"/.proxyrc.json,target=/app/.proxyrc.json \
+  --env-file .env \
+  -p 3001:3001 \
+  europeana/api-proxy-cache
+```
+
 ## License
 
 Licensed under the EUPL v1.2.

--- a/deploy/cloud-foundry/Dockerfile
+++ b/deploy/cloud-foundry/Dockerfile
@@ -1,0 +1,16 @@
+# Docker image to build and deploy to Cloud Foundry.
+#
+# This does *not* run the proxy/cache app, but is used as the agent in its
+# Jenkins Pipeline.
+
+FROM debian:stable-slim
+
+WORKDIR /app
+
+# Install CF CLI
+RUN apt-get -q update && apt-get -yq install gnupg apt-transport-https wget \
+  && wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - \
+  && echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list \
+  && apt-get -q update && apt-get -yq install cf-cli \
+  && rm -rf /var/lib/apt/lists/* \
+  && cf install-plugin blue-green-deploy -f -r CF-Community

--- a/deploy/cloud-foundry/Jenkinsfile
+++ b/deploy/cloud-foundry/Jenkinsfile
@@ -4,7 +4,8 @@ pipeline {
   }
   agent {
     dockerfile {
-      args "-u root:root"
+      dir 'deploy/cloud-foundry'
+      args '-u root:root'
     }
   }
   environment {
@@ -26,7 +27,7 @@ pipeline {
       }
       steps {
         configFileProvider([configFile(fileId: "portaljs-api-proxy-cache.${env.CF_SPACE}.env", targetLocation: '.env')]) {
-          sh 'cf blue-green-deploy ${CF_APP_NAME} -f manifest.yml --delete-old-apps'
+          sh 'cf blue-green-deploy ${CF_APP_NAME} -f deploy/cloud-foundry/manifest.yml --delete-old-apps'
         }
       }
     }

--- a/deploy/cloud-foundry/manifest.yml
+++ b/deploy/cloud-foundry/manifest.yml
@@ -1,7 +1,7 @@
 # Cloud Foundry manifest
 ---
 buildpack: nodejs_buildpack
-command: npm run start:cluster
+command: NODE_ENV=production cservice --restartOnMemUsage 134217728 --cli false index.js
 memory: 512M
 health-check-type: process
 stack: cflinuxfs3

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint *.js",
     "start": "node index.js",
-    "start:cluster": "cross-env NODE_ENV=production cservice --restartOnMemUsage 134217728 --cli false index.js"
+    "start:cluster": "cservice --cli false index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Move Cloud Foundry deployment files under deploy/cloud-foundry/
* Remove environment-specific memory limits from default cluster startup command
* Add a Dockerfile for an image to build and running the app itself, to use when publishing to Dockerhub
* Document use of app with Docker